### PR TITLE
Import old talks from original Jekyll repository

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -143,6 +143,7 @@ Voici l'organisation des principaux répertoires du projet :
 
 * **.github** : On trouve ici les fichiers d'aide sur le projet et les templates pour Github.
 * **.storybook** : On trouve ici les fichiers de configuration permettant le bon fonctionnement du storybook
+* **content** : On trouve ici les fichiers des contenus (talks, speakers, partners) en `.md`.
 * **e2e** : On trouve ici les fichiers des tests e2e.
 * **public** : Ce répertoire n'est pas dans le dépôt git, mais sera visible dès que vous lancerez un `build` du projet. Vous y trouverez donc les fichiers statiques finaux tels qu'ils  seront mis en ligne.
 * **src** : On trouve ici tous les fichiers propres à Gatsby ainsi que les fichiers de tests unitaires.

--- a/content/talks/2012-10-09-caencamp-5.md
+++ b/content/talks/2012-10-09-caencamp-5.md
@@ -1,0 +1,20 @@
+---
+
+title: CaenCamp &#35;5
+layout: post
+categories: Actualités
+author: Matthieu
+author_link: http://twitter.com/msadouni
+
+---
+
+
+ C'est la rentrée, les CaenCamp reprennent avec la 5ème édition et une nouvelle formule : un thème par session, avec une présentation suivie d'un atelier. 
+
+#### Au programme
+
+ Présentation du versioning avec Git par [Matthieu Sadouni](http://twitter.com/msadouni), suivi d'un atelier d'échange : aide à l'installation, premiers pas et échanges de connaissances. Amenez vos ordinateurs !
+
+#### Qui, quand, où ?
+
+ Ce CaenCamp est ouvert à tous et de tout niveau, le jeudi 18 octobre à 18h au [Forum Digital](http://www.forum-digital.fr)

--- a/content/talks/2012-11-12-introduction-au-developpement-par-les-tests.md
+++ b/content/talks/2012-11-12-introduction-au-developpement-par-les-tests.md
@@ -1,0 +1,27 @@
+---
+
+title: Introduction au développement par les tests
+layout: post
+categories: Actualités
+author: Clément
+author_link: http://twitter.com/clm_a
+
+---
+
+#### Au programme
+
+
+Introduction technique et méthodologique au développement par les tests
+
+Le développement par les tests (test driven development) permet une industrialisation agile du processus de création de logiciel.
+
+Cette 6è édition du CaenCamp vous propose de découvrir cette discipline tant sur un plan technique que méthodologique.
+
+Nous en découvrirons ses principaux bénéfices ainsi que sa mise en oeuvre dans un flot de travail agile, avant de mettre en place un atelier pour répondre aux questions techniques spécifiques.
+
+#### Qui, quand, où ?
+
+
+Le CaenCamp #6 aura lieu le jeudi 15 novembre à partir de 18h au [Forum Digital](http://www.forum-digital.fr), partenaire de l'évènement.
+
+L'entrée est gratuite et la séance sera accompagnée d'un petit apéro.

--- a/content/talks/2012-12-06-git-pratique.md
+++ b/content/talks/2012-12-06-git-pratique.md
@@ -1,0 +1,17 @@
+---
+
+title: "CaenCamp de Noël : Git pratique"
+layout: post
+categories: Actualités
+author: Matthieu
+author_link: http://twitter.com/msadouni
+
+---
+
+#### Au programme
+
+Après la présentation de Git en octobre dernier, nous vous proposons d’aller plus loin dans l’utilisation au quotidien de cet outil : branches, rebasing, reset, commits partiels, etc. Un atelier suivra la présentation pour mettre en pratique les thèmes abordés.
+
+#### Qui, quand, où ?
+
+Le CaenCamp #7 aura lieu le jeudi 20 décembre au Forum Digital. Accueil à partir de 18h30, démarrage à 19h. Comme d’habitude, l’entrée et l’apéro sont gratuits !

--- a/content/talks/2013-01-11-caencamp-8.md
+++ b/content/talks/2013-01-11-caencamp-8.md
@@ -1,0 +1,23 @@
+---
+
+title: "CaenCamp #8 : initiation à Sass, Compass et Susy"
+layout: post
+categories: Actualités
+author: Matthieu
+author_link: http://twitter.com/msadouni
+
+---
+
+Pour le premier CaenCamp de l'année, [Pierre-Emmanuel Fringant](https://twitter.com/pefringant) nous présentera Sass, Compass et Susy.
+
+#### Au programme
+
+Démonstration de l'utilité et de la facilité d'utilisation du préprocesseur CSS SASS, du framework Compass et de son plugin de grilles Susy.
+
+À travers des exemples concrets, nous passerons en revue les opérations simples permettant de programmer une feuille de style rapidement et proprement.
+
+#### Qui, quand, où ?
+
+Cette présentation intéressera les intégrateurs souhaitant industrialiser leur production, les graphistes désirant s'essayer au prototypage rapide sur navigateur, et les développeurs à qui les CSS donnent la migraine.
+
+Rendez-vous jeudi 31 janvier à partir de 18h45 au [Forum Digital](http://www.forum-digital.fr)

--- a/content/talks/2013-02-15-caencamp-9-git-submodules.md
+++ b/content/talks/2013-02-15-caencamp-9-git-submodules.md
@@ -1,0 +1,21 @@
+---
+
+title: "CaenCamp #9 : Git, comprendre les submodules"
+layout: post
+categories: Actualités
+author: Matthieu
+author_link: http://twitter.com/msadouni
+
+---
+
+Pour le CaenCamp de février, [Sylvain Zyssman](https://twitter.com/sylzys) nous présentera l'utilisation des submodules de Git.
+
+#### Au programme
+
+Démonstration de l'utilité des submodules pour gérer les dépendances d'un projet  et de la facilité d'utilisation : avantages, inconvénients et examples d'utilisation. Le tout en live coding !
+
+#### Qui, quand, où ?
+
+Cette présentation intéressera les débutants souhaitant aller plus loin sur Git, ainsi que les utilisateurs chevronnés désireux d'en savoir plus sur leur SCM préféré :-).
+
+Rendez-vous jeudi 28 février à partir de 18h45 au [Forum Digital](http://www.forum-digital.fr)

--- a/content/talks/2013-03-08-caencamp-10-programmation-binome.md
+++ b/content/talks/2013-03-08-caencamp-10-programmation-binome.md
@@ -1,0 +1,29 @@
+---
+
+title: "CaenCamp #10 : La programmation en binôme, c'est magique !"
+layout: post
+categories: Actualités
+author: Matthieu
+author_link: http://twitter.com/msadouni
+
+---
+
+Le CaenCamp de mars sera agile : à l'occasion du [Printemps Agile](http://www.club-agile-caen.fr/printemps-agile/), [Frédéric Leguédois](https://twitter.com/f_leguedois) nous présentera les avantages de la programmation en binôme, ou "pair-programming".
+
+#### Au programme
+
+Quelle drôle d’idée que deux personnes réalisent une tâche pouvant être
+réalisée par une seule personne ? Cela ne multiplie-t-il pas les coûts
+par deux ? Si la programmation en binôme (pair programming) est une
+bonne pratique Agile, recommandée notamment dans l’eXtrème Programming,
+elle soulève bien des interrogations et son utilité n’est pas intuitive.
+
+Or à l’usage elle transforme radicalement l’activité d’une équipe de
+développement, tant d’un point vue technique qu’humain. Et si les
+premiers effets positifs se font ressentir rapidement, des effets sur le
+long terme, plus inattendus mais tout aussi bénéfiques, émergent aussi.
+
+#### Quand, où ?
+
+Rendez-vous jeudi 28 mars à partir de 18h45 au [Forum Digital](http://www.forum-digital.fr)
+

--- a/content/talks/2013-04-11-caencamp-11-vagrant.md
+++ b/content/talks/2013-04-11-caencamp-11-vagrant.md
@@ -1,0 +1,26 @@
+---
+
+title: "CaenCamp #11 : Virtualisez vos environnements de développement avec Vagrant"
+layout: post
+categories: Actualités
+author: Clément
+author_link: http://twitter.com/clm_a
+
+---
+
+#### Au programme
+
+[Vagrant](http://www.vagrantup.com) est le chaînon manquant entre [VirtualBox](http://www.virtualbox.org) et les environnements  hétérogènes sur lesquels un développeur amené à travailler pour ses projets.
+
+Avec quelques lignes de configuration, Vagrant permet de simuler un environnement de production, de composer un réseau d'ordinateurs et de distribuer l'ensemble à ses collègues sans apporter la moindre modification à leur système.
+
+Au travers d'une démonstration, vous constaterez la simplicité de mise en place de Vagrant, l'étendue de ses possibilités et les avantages évidents qu'il apporte.
+
+#### Pour qui ?
+
+Cette présentation est ouverte aux développeurs de tous niveaux, travaillant (et c'est l'intérêt) sur tout type d'environnement.
+
+#### Où, Quand ?
+
+Rendez-vous le jeudi 25 avril à partir de 18h45 au Forum Digital
+

--- a/content/talks/2013-05-17-caencamp-12-backbonejs.md
+++ b/content/talks/2013-05-17-caencamp-12-backbonejs.md
@@ -1,0 +1,31 @@
+---
+
+title: "CaenCamp #12 : Backbone.js"
+layout: post
+categories: Actualités
+author: Clément
+author_link: http://twitter.com/clm_a
+
+---
+
+
+#### Au programme
+
+Apportez la structure MVC à vos applications single page !
+
+[Sylvain](http://www.twitter.com/sylzys) nous propose de découvrir [Backbone.js](http://backbonejs.org), outil avec lequel vous pourrez définir modèles, vues et collections, gérer les événements sur les changements de valeurs, rafraichir automatiquement vos vues et plus encore...
+
+Venez découvrir comment au travers d'une session en live-coding !
+
+#### Pour qui ?
+
+Cette présentation est ouverte à tous les développeurs de tous niveaux.
+
+#### Où, Quand ?
+
+Rendez-vous le jeudi 30 mai à 18h45 au Forum Digital
+
+## Attention !
+
+Bien que l'entrée soit libre, une réponse est désormais souhaitée >> [***ici***](https://docs.google.com/forms/d/1tvKL-H9H5IH6E87gJTdmlDDOW6M5Ut6FsrBdSIXa9q0/viewform) <<
+

--- a/content/talks/2013-05-31-backbonejs.md
+++ b/content/talks/2013-05-31-backbonejs.md
@@ -1,0 +1,12 @@
+---
+
+title: "Backbone.js"
+layout: post
+categories: Actualités
+author: Clément
+author_link: http://twitter.com/clm_a
+
+---
+
+Voici le code utilisé par [Sylvain](http://twitter.com/sylzys) pour sa présentation de Backbone.js lors du CaenCamp #12 du 30 mai : [c'est ici](https://github.com/sylzys/backbonejs-introduction)
+

--- a/content/talks/2013-05-31-sondage.md
+++ b/content/talks/2013-05-31-sondage.md
@@ -1,0 +1,15 @@
+---
+
+title: Sondage
+layout: post
+categories: Actualités
+author: Clément
+author_link: http://twitter.com/clm_a
+
+---
+
+Le CaenCamp évolue et souhaite votre avis !
+
+# [C'est ici que ça se passe](https://docs.google.com/forms/d/15HHUxy5hw22a8Loba0XGaPO8ptCDmUL1mceayg_2pyM/viewform)
+
+Merci pour votre participation et à bientôt !

--- a/content/talks/2013-06-24-caencamp-13-rails-angular.md
+++ b/content/talks/2013-06-24-caencamp-13-rails-angular.md
@@ -1,0 +1,34 @@
+---
+
+title: "CaenCamp #13 : Rails + AngularJS + TDD + Pair Programming"
+layout: post
+categories: Actualités
+author: Clément
+author_link: http://twitter.com/clm_a
+
+---
+
+On termine l'année en beauté :
+Prenez deux développeurs motivés, Julien Anne et Matthieu Hébert. Ajoutez de l'agile, du binômage, du TDD, du Rails et un peu d'AngularJS. Secouez le tout, laissez reposer une année et découvrez le retour d'expérience d'une équipe agile en live-coding.
+
+Loin d'une surenchère de coolitude, il s'agit bien ici d'outils parfaitement complémentaires et utilisés au quotidien par nos deux intervenants.
+
+Cette session-démo fera date dans l'histoire du CaenCamp, nous comptons sur votre présence ;
+on vous promet d'ailleurs une petite surprise en deuxième partie de soirée :)
+N'hésitez pas à inviter vos amis et collègues, on va abattre une cloison ou deux le cas échéant.
+
+Merci d'indiquer votre présence ici :
+
+### [>> RSVP <<](https://docs.google.com/forms/d/1tvKL-H9H5IH6E87gJTdmlDDOW6M5Ut6FsrBdSIXa9q0/viewform)
+
+
+### Pour qui ?
+
+Cette présentation est ouverte à tous, y compris (et surtout) à ceux qui ne sont pas familiers avec les outils.
+
+### Où, Quand, Comment ?
+
+C'est Jeudi, et comme toujours au Forum Digital.
+### Attention : le programme étant un peu chargé, on vous attend dès 18h30 !
+
+Bonne semaine et à jeudi !

--- a/content/talks/2013-10-25-caencamp-14-tour-d-horizon-et-deploiements.md
+++ b/content/talks/2013-10-25-caencamp-14-tour-d-horizon-et-deploiements.md
@@ -1,0 +1,41 @@
+---
+
+title: "CaenCamp #14 : Tour d'horizon et Déploiements automatisés"
+layout: post
+categories: Actualités
+author: Clément
+author_link: http://twitter.com/clm_a
+
+---
+
+### 1e partie : Tour d'horizon : 20 technos en 20'
+
+Avec un tour d'horizon des technos du moment en 20 minutes, nous allons recueillir les engouements et les cas d'utilisation des participants. En vrac : Grunt.js, ElasticSearch, Qt5.2, PhoneGap/Cordova, PRISM... Il y en aura pour tous les goûts.
+
+### 2e partie : Déploiements automatisés
+
+Démos à l'appui, je vous proposerai ensuite de découvrir différentes stratégies de déploiement automatisé ; scripts Capistrano, hooks Git, usage avec les serveurs d'intégration continue Jenkins ou Travis... Vos retours d'expérience sont les bienvenus !
+
+------------------------------------
+
+
+Merci d'indiquer votre présence ici :
+
+
+### [>> RSVP <<](https://docs.google.com/forms/d/1tvKL-H9H5IH6E87gJTdmlDDOW6M5Ut6FsrBdSIXa9q0/viewform)
+
+
+----------------------------------
+
+
+### Pour qui ?
+
+Cette présentation est ouverte à tous.
+
+### Où, Quand, Comment ?
+
+C'est Jeudi, et comme toujours au Forum Digital.
+
+On vous attend dès 18h45, merci d'ammener de quoi s'hydrater ou grignoter pendant les discussions !
+
+Bonne semaine et à jeudi !

--- a/content/talks/2013-11-15-caencamp-15-et-dojo.md
+++ b/content/talks/2013-11-15-caencamp-15-et-dojo.md
@@ -1,0 +1,85 @@
+---
+
+title: "En novembre, c'est CaenCamp + Coding Dojo"
+layout: post
+categories: Actualités
+author: Clément
+author_link: http://twitter.com/clm_a
+
+---
+
+Du nouveau à l'horizon ! Nous vous proposons de participer à un Coding Dojo, découvrez ce super projet ci-après.
+
+Le CaenCamp #15 aura lieu le 21 novembre, et le Dojo le 25.
+
+## CaenCamp
+
+
+### 1e partie : Se réunir sans s'endormir
+
+Présenté par [Frédéric Leguédois](http://twitter.com/f_leguedois)
+
+Les réunions sont souvent vécues comme un mal nécessaire. Longues et ennuyeuses à souhaits, mais aussi chronophages et coûteuses, elles ne rythment pas tant la vie de l'entreprise qu'elles ne la sclérosent.
+
+Loin des recommandations classiques (ordre du jour, compte rendu de réunion...) cette présentation illustrera à partir d'exemples vécus, qu'il est possible de dynamiser grandement les temps d'échanges d'idées.
+
+### 2e partie : Paiements pour développeurs
+
+Implémentez le paiement en ligne sur-mesure en quelques lignes de code pour jongler avec les numéros de carte bleues en toute sécurité et monétiser votre projet.
+
+Il s'agit là d'apporter une vraie plus-value à votre service, en proposant un canal de paiement parfaitement intégré *àla* Amazon et d'éviter la fameuse redirection vers Paypal ou un site bancaire.
+Avec les mêmes avantages, le mode de fonctionnement en marketplace permet aux visiteurs de votre site de directement payer un vendeur.
+
+Nous ferons un tour d'horizon des différentes solutions du marché, et je vous proposerai ensuite une mise en oeuvre de [Paymill](http://paymill.com) dans un mini-projet créé pour l'occasion.
+
+### Pour qui ?
+
+Cette présentation est ouverte à tous. Merci d'indiquer votre présence [ici](https://docs.google.com/forms/d/1tvKL-H9H5IH6E87gJTdmlDDOW6M5Ut6FsrBdSIXa9q0/viewform).
+
+### Où, Quand, Comment ?
+
+C'est Jeudi 21/11, comme toujours au Forum Digital.
+
+On vous attend dès 18h45, merci d'ammener de quoi s'hydrater et grignoter pendant les discussions !
+
+
+
+
+--------------------------
+
+## Coding Dojo Ruby on Rails / AngularJS : les mains dans le cambouis
+
+Proposé par [Julien Anne](http://twitter.com/Julien_ANNE) et moi-même.
+
+Rails est un framework qui est devenu, en dix ans, l'un des outils de conception web de référence.
+Il a inspiré de nombreux frameworks dans d'autres langages (CakePHP, Yii, Symfony, Grails, on encore Play).
+Son équilibre entre dogmatisme et modularité en font un candidat idéal pour tout projet nécessitant un processus de déploiement industrialisé (Rails peut fonctionner par défaut avec SASS / Compass, CoffeeScript, Sprockets...).
+
+Qu'est-ce qu'un Dojo ?
+C'est une réunion ou les participants sont invités à travailler sur un même projet.
+Nous travaillerons sur un mode agile et chaque itération sera effectuée par un binôme différent, en développement piloté par les tests.
+
+Pendant ces Dojos, vous allez plonger dans le grand bain, en suivant et en contribuant à un projet ambitieux (parmi plusieurs proposés) mettant en œuvre Rails, AngularJS et la communication client-serveur temps réel.
+
+Le but de ces ateliers est avant tout l'auto-apprentissage, sous notre œil bienveillant (nous tiendrons également le rôle de Product Owner) et nous pourrons à tout moment prendre le relais, vous porter secours ou répondre à vos questions.
+
+
+### Pour qui ?
+
+Ce Dojo initialement proposé aux étudiants du Campus 2 est ouvert à tous, sur [inscription uniquement](https://docs.google.com/forms/d/1O7p8g2Rx9EmglHEhuv7_nBvyFuzYR4X1dTleqXcJHGo/viewform).
+
+### Où, Quand, Comment ?
+
+C'est le Lundi 25/11 à 17h30 au Campus 2.
+Les précisions d'accès vous seront transmises par e-mail.
+
+Nous espérons vous voir nombreux !
+
+
+
+
+### Bon weekend et à bientôt !
+
+
+
+

--- a/content/talks/2013-12-06-caencamp-16-et-dojo-2.md
+++ b/content/talks/2013-12-06-caencamp-16-et-dojo-2.md
@@ -1,0 +1,94 @@
+---
+
+title: "Dojo #2 le 16 et CaenCamp #16 le 19"
+layout: post
+categories: Actualités
+author: Clément
+author_link: http://twitter.com/clm_a
+
+---
+
+Le Dojo #2 aura lieu le 16 décembre et le CaenCamp #16 aura lieu le 19 ; respectivement à 17:30 et 18:45. Besoin d'un cachet d'Aspirine ?
+
+
+## Coding Dojo #2 : EmberJS/AngularJS, les mains dans le cambouis
+
+Co-Animé par [Julien Anne](http://twitter.com/Julien_ANNE) et moi-même.
+
+Après la réalisation succincte d'un back-end de Kanban, nous allons nous commencer à itérer sur la partie front-end.
+Nous nous aiderons soit d'AngularJS soit d'EmberJS, en fonction du choix des participants.
+
+Qu'est-ce qu'un Dojo ?
+C'est une réunion ou les participants sont invités à travailler sur un même projet.
+Nous travaillerons sur un mode agile et chaque itération sera effectuée par un binôme différent, en développement piloté par les tests.
+
+Pendant ces Dojos, vous allez plonger dans le grand bain, en suivant et en contribuant à un projet ambitieux (parmi plusieurs proposés) mettant en œuvre Rails, AngularJS et la communication client-serveur temps réel.
+
+Le but de ces ateliers est avant tout l'auto-apprentissage, sous notre œil bienveillant (nous tiendrons également le rôle de Product Owner) et nous pourrons à tout moment prendre le relais, vous porter secours ou répondre à vos questions.
+
+
+### Pour qui ?
+
+Ce Dojo initialement proposé aux étudiants du Campus 2 est ouvert à tous, sur [inscription uniquement](https://docs.google.com/forms/d/1O7p8g2Rx9EmglHEhuv7_nBvyFuzYR4X1dTleqXcJHGo/viewform).
+
+### Où, Quand, Comment ?
+
+C'est le Lundi 16/12 à 17h30 au Campus 2.
+Les précisions d'accès vous sont transmises par e-mail quand vous vous inscrivez.
+
+Nous espérons vous voir nombreux !
+
+
+
+
+
+
+----------------
+
+
+## CaenCamp #16 : Gestion agile de projet et Marché de Noël
+
+
+### 1e partie : Comment vivre heureux dans l'incertitude trépidante de la gestion de projets.
+
+
+#### Présentation de l'approche Agile de projet par une méthode pragmatique.
+
+La gestion de projet est une discipline passionnante, surtout quand chaque projet est unique ou que le client n'a qu'une idée vague de ce qu'il veux. Pourtant pour certain ces hésitations, l'absence de plan précis, et dans un sens large tous les imprévus sont une vraie source de stress. Comment rester zen face aux évolutions inéluctables d'un projet, comment accueillir avec plaisir le changement, en optimisant le travail de ses équipes et la qualité finale ?
+
+Vous voulez le savoir ? Venez le 19 Décembre !
+
+#### Contenu de l'intervention
+- État des lieux rapide de la gestion de projet et des méthodes traditionnelles
+- Les points de blocage pour les sociétés (ou services) à forte flexibilité.
+- Présentation de la méthode que j'utilise actuellement et qui synthétise des notions de Scrum, Kanbam, et XP, avec une touche de Kaizen.
+
+Présenté par [Mathieu Lallemand](http://twitter.com/lalmat)
+
+
+
+
+### 2e partie : Marché de Noël du CaenCamp
+
+Venez présenter votre configuration de travail, vos outils, matos, projets en cours et spécialités techniques !
+
+Nous présenterons les configurations de nos postes de travail, nos expérimentations, projets et challenges du moment.
+
+Nous installerons plusieurs ateliers que vous serez invité à visiter et/ou animer.
+
+Merci d'amener votre machine et présenter ce que vous aimez dans votre travail :)
+
+### Pour qui ?
+
+Cette session est ouverte à tous. Merci d'indiquer votre présence [ici](https://docs.google.com/forms/d/1tvKL-H9H5IH6E87gJTdmlDDOW6M5Ut6FsrBdSIXa9q0/viewform).
+
+### Où, Quand, Comment ?
+
+C'est Jeudi 19/12, comme toujours au Forum Digital.
+
+On vous attend dès 18h45, merci d'ammener de quoi s'hydrater et grignoter pendant les discussions !
+
+
+
+
+### Bon weekend et à bientôt !

--- a/content/talks/2014-01-28-caencamp-17.md
+++ b/content/talks/2014-01-28-caencamp-17.md
@@ -1,0 +1,45 @@
+---
+
+title: "CaenCamp #17"
+layout: post
+categories: Actualités
+author: Clément
+author_link: http://twitter.com/clm_a
+
+---
+
+
+
+Une édition à ne manquer sous aucun prétexte !
+
+-------
+
+### Première Partie : le certificat x509 par Vincent Regnard
+
+J'aborderai pour ce premier #CaenCamp l'anatomie du certificat X509, ses utilités et son usage pour la sécurisation d'échange électroniques.
+
+Autour d'un cas complet concret je montrerai comment mettre en oeuvre la sécurisation d'un échange électronique avec TLS et un certificat X509. A travers cette présentation nous aborderons et préciserons le jargon technique associé, évoquerons les différents formats, utiliserons les différents outils indispensables, et échangerons sur les bonnes pratiques afin de nous familiariser avec l'objet "certificat électronique".
+
+Mots clefs: X509, certificat, PKI, Autorité de Certification, TLS, SSL, openssl
+
+--------
+
+### Deuxième Partie : Symfony 2, tour d'horizon et retour d'expérience.
+
+Sylvain Zyssman nous proposera une découverte et un live coding des différents concepts de Symfony 2 : routing, MVC, Twig, Doctrine, ...
+
+
+### Pour qui ?
+
+Cette session est ouverte à tous. Merci d'indiquer votre présence [ici](https://docs.google.com/forms/d/1tvKL-H9H5IH6E87gJTdmlDDOW6M5Ut6FsrBdSIXa9q0/viewform).
+
+### Où, Quand, Comment ?
+
+C'est Jeudi 30/01, comme toujours au Forum Digital.
+
+On vous attend dès 18h30, merci d'ammener de quoi boire et/ou grignoter !
+
+
+
+
+### Bonne semaine et à Jeudi !

--- a/content/talks/2014-02-12-caencamp-18.md
+++ b/content/talks/2014-02-12-caencamp-18.md
@@ -1,0 +1,26 @@
+---
+
+title: "CaenCamp #18 : le préprocesseur Sass et l'Asset Pipeline"
+layout: post
+categories: Actualités
+author: Clément
+author_link: http://twitter.com/clm_a
+
+---
+
+
+Lors de deux ateliers nous verrons tout d'abord les avantages et comment tirer partie au quotidien de l'utilisation du préprocesseur CSS Sass.
+Dans la deuxième partie, nous verrons comment ces pratiques s'inscrivent dans un workflow de mise en production, en mettant l'accent sur les performances pour l'utilisateur final.
+
+
+Venez échanger vos astuces pour une intégration productive !
+
+
+### Où, Quand, Comment ?
+
+Rendez-vous le 27 février à 18:30, au [Forum Digital](http://forum-digital.fr).
+
+Cette session est ouverte à tous. Merci cependant d'indiquer votre présence [ici](https://docs.google.com/forms/d/1tvKL-H9H5IH6E87gJTdmlDDOW6M5Ut6FsrBdSIXa9q0/viewform).
+
+Merci d'ammener de quoi boire et/ou grignoter !
+

--- a/content/talks/2014-03-21-caencamp-19.md
+++ b/content/talks/2014-03-21-caencamp-19.md
@@ -1,0 +1,30 @@
+---
+
+title: "CaenCamp #19 : présentation du système GPS"
+layout: post
+categories: Actualités
+author: Matthieu
+author_link: http://twitter.com/msadouni
+
+---
+
+Laurent Jager, fort de ses 4 années d'expérience en développement et validation du système GPS d'une plateforme télématique, nous présentera les rouages du système GPS :
+
+- Un rapide historique du GPS
+- Le principe général de fonctionnement (bandes de fréquences, modulation, débit, ...)
+- Les différentes données reçues par les récepteurs GPS et leur utilité
+- Les trames NMEA (ce qui peut être reçu et traité par le logiciel)
+- Une étude générale des performances du système GPS et les techniques de test
+- Les aides au positionnement (GPS différentiel, SBAS, A-GPS)
+- Les perturbateurs qui peuvent dégrader les performances.
+
+La présentation devrait durer 40 minutes, suivie d'une session de questions/réponses autour de l'habituel apéro !
+
+### Où, Quand, Comment ?
+
+Rendez-vous le 27 mars à 18:30, au [Forum Digital](http://forum-digital.fr).
+
+Cette session est ouverte à tous. Merci cependant d'indiquer votre présence [ici](https://docs.google.com/forms/d/1tvKL-H9H5IH6E87gJTdmlDDOW6M5Ut6FsrBdSIXa9q0/viewform).
+
+Merci d'amener de quoi boire et/ou grignoter !
+

--- a/content/talks/2014-04-23-caencamp-20.md
+++ b/content/talks/2014-04-23-caencamp-20.md
@@ -1,0 +1,23 @@
+---
+
+title: "CaenCamp #20 : apéro-forum sur le thème du télétravail"
+layout: post
+categories: Actualités
+author: Matthieu
+author_link: http://twitter.com/msadouni
+
+---
+
+Changement de formule pour cette vingtième édition : nous organisons un apéro-forum autour du thème du télétravail.
+
+Que vous soyez déjà adepte ou simplement intéressé par ce mode de travail, le but est de discuter des avantages et difficultés rencontrées, s'échanger des trucs, astuces et outils pour s'organiser...
+
+Le tout bien sûr autour d'un verre !
+
+### Où, Quand, Comment ?
+
+Rendez-vous le 24 avril à partir de 18h00, au [Forum Digital](http://forum-digital.fr).
+
+Cette session est ouverte à tous. Merci cependant d'indiquer votre présence [ici](https://docs.google.com/forms/d/1tvKL-H9H5IH6E87gJTdmlDDOW6M5Ut6FsrBdSIXa9q0/viewform).
+
+Merci d'amener de quoi boire et/ou grignoter !

--- a/content/talks/2014-06-20-caencamp-22.md
+++ b/content/talks/2014-06-20-caencamp-22.md
@@ -1,0 +1,26 @@
+---
+
+title: "CaenCamp #22 : la performance Web"
+layout: post
+categories: Actualités
+author: Matthieu
+author_link: http://twitter.com/msadouni
+
+---
+
+Le Web est en pleine évolution. Malgré l'amélioration constante des connexions, tous les utilisateurs ne sont pas logés à la même enseigne. L'essor des terminaux mobiles est également à prendre en compte.
+
+Dans ces conditions variables, les attentes des internautes/mobinautes en terme de rapidité est grandissante, la performance prend donc une dimension de plus en plus importante.
+
+Découvrons ensemble quels sont les points à cibler pour répondre à ces attentes, quels outils et indicateurs peuvent nous être utiles...
+
+Objectif: 1000ms !
+
+### Où, Quand, Comment ?
+
+Rendez-vous le 26 juin à partir de 18h30, au [Forum Digital](http://forum-digital.fr).
+
+Cette session est ouverte à tous. Merci cependant d'indiquer votre présence [ici](https://docs.google.com/forms/d/1tvKL-H9H5IH6E87gJTdmlDDOW6M5Ut6FsrBdSIXa9q0/viewform).
+
+Merci d'amener de quoi boire et/ou grignoter !
+

--- a/content/talks/2014-09-17-caencamp-23-svg.md
+++ b/content/talks/2014-09-17-caencamp-23-svg.md
@@ -1,0 +1,26 @@
+---
+
+title: "CaenCamp #23 : SVG, format clé du responsive"
+layout: post
+categories: Actualités
+author: Matthieu
+author_link: http://twitter.com/msadouni
+
+---
+
+Le format SVG est en plein essor depuis l'avènement du responsive design.
+
+Nous commencerons par évaluer les situations pour lesquelles le format SVG est adapté, exemples tirés de cas réels à l'appui.
+
+Nous passerons en revue les nombreuses façons de l'intégrer dans une page et le support correspondant dans les navigateurs.
+
+Nous verrons ensuite comment le manipuler en CSS et en Javascript, et comment l'intégrer dans son flux de production.
+
+### Où, Quand, Comment ?
+
+Rendez-vous le 25 septembre à partir de 18h30, au [Forum Digital](http://forum-digital.fr).
+
+Cette session est ouverte à tous. Merci cependant d'indiquer votre présence [ici](https://docs.google.com/forms/d/1tvKL-H9H5IH6E87gJTdmlDDOW6M5Ut6FsrBdSIXa9q0/viewform).
+
+Merci d'amener de quoi boire et/ou grignoter !
+

--- a/content/talks/2014-10-28-caencamp-24-scala.md
+++ b/content/talks/2014-10-28-caencamp-24-scala.md
@@ -1,0 +1,20 @@
+---
+
+title: "CaenCamp #24 : La programmation fonctionnelle avec Scala"
+layout: post
+categories: Actualités
+author: Clément
+author_link: http://twitter.com/clm_a
+
+---
+
+Pour ce CaenCamp, [@Korbik](http://twitter.com/korbik) nous propose de découvrir la Programmation fonctionnelle et Scala.
+
+### Où, Quand, Comment ?
+
+Rendez-vous le 30 octobre à partir de 18h30, au [Forum Digital](http://forum-digital.fr).
+
+Cette session est ouverte à tous. Merci cependant d'indiquer votre présence [ici](https://docs.google.com/forms/d/1tvKL-H9H5IH6E87gJTdmlDDOW6M5Ut6FsrBdSIXa9q0/viewform).
+
+Merci d'amener de quoi boire et/ou grignoter !
+

--- a/content/talks/2014-12-12-caencamp-25-noel.md
+++ b/content/talks/2014-12-12-caencamp-25-noel.md
@@ -1,0 +1,51 @@
+---
+
+title: "CaenCamp #25 : Édition de Noël"
+layout: post
+categories: Actualités
+author: Clément
+author_link: http://twitter.com/clm_a
+
+---
+
+# Édition spéciale de Noël !
+
+
+Le 18 décembre aura lieu le dernier CaenCamp de 2014 !
+
+
+Il s'agit d'une édition particulièrement chargée !
+
+Au programme :
+
+* Je vous proposerai une démonstration du framework JavaScript MVVM **Vue.js** (les avantages d'AngularJS sans les inconvénients), utilisé avec Webpack, pour produire un front-end partagé entre une application hybride Cordova / PhoneGap et un site internet.
+
+* On verra ensuite l'astuce de Sioux du moment : l'utilisation de **Cloudflare** pour sécuriser toutes les connexions web avec un certificat HTTPS universel, valide et... gratuit !
+
+* Nous déclarerons enfin ouvert **le marché de Noël du CaenCamp**, où vous aurez la possibilité de (re)découvrir les compétences de chacun pour, par exemple, trouver l'aide dont vous avez besoin pour un projet ou du techno-bricolage. Vous pouvez venir avec vos machines pour faire des démos !
+Pour mener à bien ce marché de Noël, nous vous invitons à suivre le lien ci-après.
+
+
+
+Cette fois-ci, l'inscription est plus que souhaitée : elle est **très fortement souhaitée** ; afin d'expérimenter sérieusement le recoupement de compétences lors de la soirée.
+
+
+
+**Merci de vous inscrire au plus vite** et d'indiquer ce que vous aimez et souhaitez expérimenter :
+
+[https://docs.google.com/forms/d/1RyL4F0AcPKbrj2q5pMK-ZnIik8yb9kQZ640PRRbZXgo/viewform](https://docs.google.com/forms/d/1RyL4F0AcPKbrj2q5pMK-ZnIik8yb9kQZ640PRRbZXgo/viewform)
+
+
+
+**Nous souhaitons vraiment clôturer l'année en beautée et faire notre plus belle édition**.
+Nous vous attendons donc (très) nombreux et chargés de cadeaux à partager (boisson, biscuits, ...) !
+
+
+Nous avons de beaux et interessants projets pour 2015 mais nous avons besoin de votre (simple) présence pour les mener à bien.
+
+**Faites passer l'info** et n'hésitez pas à faire venir les (rares) personnes qui n'ont pas encore fréquenté le CaenCamp ;)
+
+Rendez-vous donc jeudi 18 décembre à 18h30 au [Forum Digital](http://www.forum-digital.fr) ; c'est bien sûr toujours gratuit !
+
+
+Clément

--- a/content/talks/2015-02-23-caencamp-26-gmt.md
+++ b/content/talks/2015-02-23-caencamp-26-gmt.md
@@ -1,0 +1,29 @@
+---
+
+title: "CaenCamp #26 : Golden Master Testing"
+layout: post
+categories: Actualités
+author: Clément
+author_link: http://twitter.com/clm_a
+
+---
+
+En marge du [printemps agile](http://www.club-agile-caen.fr/printempsagile/), [Matthieu](https://twitter.com/msadouni) et [Pierre-Emmanuel](https://twitter.com/pefringant) nous proposent de découvrir en avant-première leur intervention sur le Golden Master Testing.
+
+## Le Golden Master Testing, c'est quoi ?
+
+> MH Communication est une agence de développement web sur mesure. De la conception à la maintenance, nous accompagnons nos clients pour faire évoluer leur application. Certains projets durant parfois plusieurs années, nous utilisons au quotidien des techniques comme le BDD et le TDD pour assurer la pérennité de nos développements. Cependant, nous sommes amenés à reprendre des projets réalisés par d’autres équipes, ainsi qu’à assurer la maintenance d’anciennes bases de code. Dans ce cas, les tests sont parfois incomplets, souvent inexistants. Comment alors s’assurer que la correction de bugs ou le développement de nouvelles fonctionnalités ne vont pas engendrer des effets de bords indésirables, détectés souvent trop tard, dans d’autres parties critiques de l’application ?
+
+> Il est très difficile d’adopter les techniques classiques de tests unitaires sur une application non testée car son code n’a pas été prévu en conséquence. Pire encore, dans le cas de reprise d’une application existante, son fonctionnement même très souvent inconnu.
+
+> Plutôt que de vérifier les différents cas d’utilisation des modules de l’application, le principe du Golden Master Testing est d’écrire des tests qui s’assurent que le fonctionnement actuel de l’application ne change pas : pour un ensemble de paramètres donnés, la sortie de l’application ne doit pas varier.
+
+> Ces tests ne remplacent pas les tests unitaires et d’intégration mais permettent d’ériger une sorte d’échafaudage autour d’une application inconnue ou mal testée. Cela permet d’apprendre son fonctionnement et de livrer rapidement des corrections et évolutions, tout en renforçant au fil du temps la suite de tests classiques.
+
+> Le but de cette session est de présenter un retour d’expérience sur l’utilisation du Golden Master Testing, ainsi que différents outils et techniques pour l’appliquer à vos propres projets.
+
+## C'est pour qui ?
+
+Cette session est ouverte à tous. Comme d'habitude, merci d'amener de quoi partager un morceau ou un verre.
+
+Rendez-vous jeudi 26 février à 18h30 au [Forum Digital](http://forum-digital.fr/fr/acces-et-localisation-du-forum-digital-de-caen-colombelles.-gc16.html)

--- a/content/talks/2015-05-12-caencamp-27-wordpress.md
+++ b/content/talks/2015-05-12-caencamp-27-wordpress.md
@@ -1,0 +1,17 @@
+---
+
+title: "CaenCamp #27 : Peut-on travailler proprement avec Wordpress ?"
+layout: post
+categories: Actualités
+author: Matthieu
+author_link: http://twitter.com/msadouni
+
+---
+
+Wordpress est un outil formidable très utilisé dans le monde. Cette popularité doit certainement beaucoup à la simplicité de son installation. Mais peut-on l'intégrer dans un flux de production moderne ? Versioning, déploiement automatisé, machine virtuelle, tests... Ce 27ème CaenCamp présenté par [Pierre-Emmanuel](https://twitter.com/pefringant) sera l'occasion de partager les expériences et de débattre sur la pertinence de choisir Wordpress comme outil de travail.
+
+## C'est pour qui ?
+
+Cette session est ouverte à tous. Comme d'habitude, merci d'amener de quoi partager un morceau ou un verre.
+
+Rendez-vous jeudi 4 juin à 18h30 au [Forum Digital](http://forum-digital.fr/fr/acces-et-localisation-du-forum-digital-de-caen-colombelles.-gc16.html)

--- a/content/talks/2017-03-28-caencamp-28-le-graphql-c-est-vraiment-la-fin-du-rest.md
+++ b/content/talks/2017-03-28-caencamp-28-le-graphql-c-est-vraiment-la-fin-du-rest.md
@@ -1,0 +1,19 @@
+---
+title: "CaenCamp #28 : Le GraphQL, c'est vraiment la fin du REST ?"
+layout: post
+author: Alexis Janvier
+author_link: https://twitter.com/alexisjanvier
+date: 2017-03-28T18:30:00+0200
+---
+
+Alexis Janvier fera une intervention sur le GraphQL: parfois présenté comme le
+successeur des API Rest, le graphQL fait briller les yeux de nombreux
+développeurs. Mais est-ce que c'est aussi bon que ça ?
+
+<!-- more -->
+
+## C'est pour qui ?
+
+Cette session est ouverte à tous.
+
+Rendez-vous jeudi 28 mars à 18h30 au [Forum Digital](http://forum-digital.fr/fr/acces-et-localisation-du-forum-digital-de-caen-colombelles.-gc16.html)

--- a/content/talks/2017-04-25-caencamp-29-architecture-flux-alternative-au-mvc.md
+++ b/content/talks/2017-04-25-caencamp-29-architecture-flux-alternative-au-mvc.md
@@ -1,0 +1,27 @@
+---
+title: "CaenCamp #29 : Architecture flux : Alternative au MVC ?"
+layout: post
+author: Clément Lebiez
+author_link: https://twitter.com/clebiez
+date: 2017-04-25T18:30:00+0200
+---
+
+Clément Lebiez viendra nous parler de *Flux*.
+
+> Flux n'est pas un framework, mais plutôt une architecture, une façon de penser permettant de résoudre les problèmes de scalabilité et de maintenance que l'on peut rencontrer dans le développement d'applications webs volumineuses.
+> Nous aborderons la mise en place d'un projet front-end en utilisant l'architecture Flux pour en tirer ses avantages et ses inconvénients.
+> Cette architecture nouvelle, propulsé par Facebook avec son framework JavaScript React est-elle une alternative prometteuse au MVC traditionnel ? 
+
+<!-- more -->
+
+## C'est pour qui ?
+
+Cette session est ouverte à tous.
+
+## Ça se passe où ?
+
+Rendez-vous mardi 25 avril à 18h30 au [Forum Digital](http://forum-digital.fr/fr/acces-et-localisation-du-forum-digital-de-caen-colombelles.-gc16.html)
+
+## Je veux venir !
+
+Inscrivez-vous sur MeetUp : [#29 Architecture flux : Alternative au MVC ?](https://www.meetup.com/CaenCamp/events/239134605/).

--- a/content/talks/2017-05-30-caencamp-30-premiers-pas-avec-docker.md
+++ b/content/talks/2017-05-30-caencamp-30-premiers-pas-avec-docker.md
@@ -1,0 +1,30 @@
+---
+title: "CaenCamp #30 : Premiers pas avec docker"
+layout: post
+author: Jérémy Leherpeur
+author_link: https://twitter.com/Jleherpeur
+date: 2017-05-30T18:30:00+0200
+---
+
+> Docker est un logiciel libre qui automatise le déploiement d'applications
+> dans des conteneurs logiciels
+
+— Wikipédia.
+
+Vous n'avez toujours pas une flotte de conteneurs sur votre laptop ? Venez
+découvrir pourquoi certains n'installent même plus PHP ou MySQL sur leur
+machine.
+
+<!-- more -->
+
+## C'est pour qui ?
+
+Cette session est ouverte à tous.
+
+## Ça se passe où ?
+
+Rendez-vous jeudi 30 mai à 18h30 au [Forum Digital](http://forum-digital.fr/fr/acces-et-localisation-du-forum-digital-de-caen-colombelles.-gc16.html)
+
+## Je veux venir !
+
+Inscrivez-vous sur MeetUp : [CaenCamp #30 : Premiers pas avec docker](https://www.meetup.com/CaenCamp/events/240062370/).

--- a/content/talks/2017-06-27-devenir-un-git-master.md
+++ b/content/talks/2017-06-27-devenir-un-git-master.md
@@ -1,0 +1,27 @@
+---
+title: "CaenCamp #31 : Devenir un git master"
+layout: post
+author: Antoine Lelaisant
+author_link: https://twitter.com/AntoineLelaisan
+date: 2017-06-27T18:30:00+0100
+---
+
+Git c'est bien, le maîtriser pleinement, c'est mieux. En effet, git ne se résume pas à faire des commit, pull ou push, il dispose de plein d'autres fonctionnalités super puissantes pour vous aider à garder votre arbre propre.  Ne tremblez plus des genoux lorsque vous faites un `git push --force`, apprenons ensemble à réécrire l'histoire !
+
+Vous avez déjà perdu du code à cause d'un rebase ou un merge douteux ? Git n'oublie jamais ! Il y a toujours une possibilité pour récupérer ce code perdu :)
+
+Je vous présenterais également quelques retours d'expérience sur les git flows que j'ai pu expérimenter.
+
+<!-- more -->
+
+## C'est pour qui ?
+
+Cette session est ouverte à tous.
+
+## Ça se passe où ?
+
+Rendez-vous mardi 27 juin à 18h30 à [l'IMIE](http://imie-ecole-informatique.fr/campus/caen.html), 10 place François Mitterrand, Hérouville-Saint-Clair.
+
+## Je veux venir !
+
+Inscrivez-vous sur MeetUp : [CaenCamp #31 : Devenir un git master](https://www.meetup.com/CaenCamp/events/240781536/).

--- a/content/talks/2017-09-26-jest.md
+++ b/content/talks/2017-09-26-jest.md
@@ -1,0 +1,25 @@
+---
+title: "CaenCamp #32 : Tester son code Javascript avec Jest"
+layout: post
+author: Jonathan
+author_link: https://twitter.com/Sethpolma
+date: 2017-09-26T18:30:00+0100
+---
+
+Pour cette #32 édition de reprise, c'est Jonathan de chez Marmelab qui viendra de sa lointaine Lorraine pour nous parler de Jest.  
+
+Jest est la solution recommandée pour tester une application React. Aucune configuration, mocks automatiques, rapidité d'exécution, confort de développement... Promesses marketing ou réalité quotidienne ? Pour le savoir, développons ensemble une application React de base, et testons Jest en conditions réelles.
+
+<!-- more -->
+
+## C'est pour qui ?
+
+Cette session est ouverte à tous.
+
+## Ça se passe où ?
+
+Rendez-vous mardi 26 juin à 18h30 au [Forum Digital](http://forum-digital.fr/fr/acces-et-localisation-du-forum-digital-de-caen-colombelles.-gc16.html).
+
+## Je veux venir !
+
+Inscrivez-vous sur MeetUp : [CaenCamp #32 : Tester son code Javascript avec Jest](https://www.meetup.com/fr-FR/CaenCamp/events/243340117/).

--- a/content/talks/2017-10-31-infrastructures-a-cles-publiques.md
+++ b/content/talks/2017-10-31-infrastructures-a-cles-publiques.md
@@ -1,0 +1,21 @@
+---
+title: "CaenCamp #33 : Infrastructures à Clés Publiques"
+layout: post
+author: Romain Tartière
+author_link: https://romain.blogreen.org
+date: 2017-10-31T18:30:00+0100
+---
+
+Au delà d'une simple description des moyens techniques permettant d'établir une garantie de confiance dans la validité d'une identité numérique, [Romain Tartière](https://mamot.fr/@smortex) abordera également l'importance du facteur humain au sein de ce type d'infrastructure.
+
+Afin de participer a à l'agrandissement des réseaux de confiances à la fin de la conférence, les utilisateur·trice·s de GnuPG sont invité·e·s à se munir de plusieurs copies de l'empreinte de leur clé et d'une pièce d'identité ; et les utilisateur·trice·s de CAcert d'un "WoT-Form" et de deux pièces d'identité. 
+
+<!-- more -->
+
+## C'est pour qui ?
+
+Cette session est ouverte à toutes et à tous.
+
+## Je veux voir les slides !
+
+C'est par ici: [Infrastructures à clés publiques](https://romain.blogreen.org/files/2017-10-31-pki.pdf).


### PR DESCRIPTION
Issue reference: #7 

## Description
Importing markdown files about past talks from the old site.
