### PR TITLE
[fix][code] gestion des dates dans le passé (#52)

### DIFF
--- a/src/components/talks/listItem.js
+++ b/src/components/talks/listItem.js
@@ -1,7 +1,7 @@
 import Link from 'gatsby-link';
 import React, { Component } from 'react';
 import styled from 'styled-components';
-import isPast from 'date-fns/is_past';
+import isBefore from 'date-fns/is_before';
 
 import Calendar from './Calendar';
 import MinimalView from '../speakers/MinimalView';
@@ -112,7 +112,7 @@ export default class ListItem extends Component {
                             }
                         />
                     </Description>
-                    {!isPast(new Date(talk.date)) &&
+                    {isBefore(new Date(), new Date(talk.date)) &&
                         talk.meetupId && (
                             <Registration>
                                 <a

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,6 @@
 import { Helmet } from 'react-helmet';
 import React from 'react';
-import isPast from 'date-fns/is_past';
+import isBefore from 'date-fns/is_before';
 import styled from 'styled-components';
 import 'font-awesome/css/font-awesome.css';
 
@@ -28,7 +28,7 @@ export default ({ data }) => {
 
     let lastTalk = null;
     let nextTalk = null;
-    if (isPast(new Date(talks[0].date))) {
+    if (!isBefore(new Date(), new Date(talks[0].date))) {
         lastTalk = talks[0];
     } else {
         lastTalk = talks[1];
@@ -37,7 +37,7 @@ export default ({ data }) => {
     const cccs = data.cccs.edges.map(camp => formatGraphContent(camp.node));
     let lastCamp = null;
     let nextCamp = null;
-    if (isPast(new Date(cccs[0].date))) {
+    if (!isBefore(new Date(), new Date(cccs[0].date))) {
         lastCamp = cccs[0];
     } else {
         lastCamp = cccs[1];


### PR DESCRIPTION
Issue reference: #52 

## Description

J'ai changé le `isPast` en `isBefore` et fixé le problème de dates, ça vous permettra d'avoir moins de refacto à faire si vous passez un jour sur date-fns@2 (on est encore en alpha) puisque `isPast` n'existe plus en V2.

Happy Hacktoberfest 👍 