### PR TITLE
Fix video player controls on Youtube

### DIFF
--- a/src/templates/talk.js
+++ b/src/templates/talk.js
@@ -118,6 +118,7 @@ export default ({ data }) => {
                                 url={talk.video}
                                 width="100%"
                                 height="100%"
+                                controls="true"
                             />
                         </VideoContainer>
                     )}


### PR DESCRIPTION
Issue reference: #54 

## Description

Dans le module React player : https://www.npmjs.com/package/react-player
Il manquait juste à passer la props controls à true sur le component.