### PR TITLE
Fix content wrapper on mobile view + refacto BackToList component

### DIFF
--- a/src/components/BackToList.js
+++ b/src/components/BackToList.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import Link from 'gatsby-link';
+import styled from 'styled-components';
+
+const StyledLink = styled(Link)`
+    color: ${({ theme }) => theme.black};
+`;
+
+const BackToListContainer = styled.div`
+    @media (max-width: ${props => props.theme.mobileSize}) {
+        margin-top: 1.5em;
+    }
+`;
+
+export default ({ path }) => (
+    <BackToListContainer>
+        <StyledLink to={path}>
+            <i className="fa fa-list-alt" aria-hidden="true" /> Retour à la
+            liste
+        </StyledLink>
+    </BackToListContainer>
+);

--- a/src/components/Content.js
+++ b/src/components/Content.js
@@ -5,6 +5,9 @@ export const Content = styled.section`
     flex-direction: row;
     align-items: top;
     justify-content: center;
+    @media (max-width: ${props => props.theme.mobileSize}) {
+        margin-top: 1rem;
+    }
 `;
 export const SingleColumn = styled.div`
     width: 100%;

--- a/src/templates/speaker.js
+++ b/src/templates/speaker.js
@@ -1,5 +1,4 @@
 import Helmet from 'react-helmet';
-import Link from 'gatsby-link';
 import React from 'react';
 import styled from 'styled-components';
 
@@ -8,10 +7,7 @@ import { SingleColumn } from '../components/Content';
 import TalkListItem from '../components/talks/listItem';
 import { DojoListItem } from '../components/dojos/listItem';
 import Links from '../components/speakers/Links';
-
-const StyledLink = styled(Link)`
-    color: ${({ theme }) => theme.black};
-`;
+import BackToList from '../components/BackToList';
 
 const SpeakerContainer = styled.div`
     display: flex;
@@ -68,10 +64,7 @@ export default ({ data }) => {
                 <meta name="description" content="A trouver" />
                 <meta name="keywords" content="A voir" />
             </Helmet>
-            <StyledLink to="/speakers">
-                <i className="fa fa-list-alt" aria-hidden="true" /> Retour à la
-                liste
-            </StyledLink>
+            <BackToList path="/speakers" />
             <SpeakerContainer>
                 <SpeakerBio>
                     <Profile src={`/speakers/${speaker.picture}`} />

--- a/src/templates/talk.js
+++ b/src/templates/talk.js
@@ -1,19 +1,15 @@
 import Helmet from 'react-helmet';
-import Link from 'gatsby-link';
 import React from 'react';
 import styled from 'styled-components';
 import ReactPlayer from 'react-player';
 
 import { formatTalkWithSpeakers } from '../utils/formatters';
 import { SingleColumn } from '../components/Content';
+import BackToList from '../components/BackToList';
 import SpeakerTalk from '../components/speakers/SpeakerTalk';
 import { SpeakerListItem } from '../components/speakers/listItem';
 import Calendar from '../components/talks/Calendar';
 import Tags from '../components/talks/Tags';
-
-const StyledLink = styled(Link)`
-    color: ${({ theme }) => theme.black};
-`;
 
 const TalkContainer = styled.div`
     display: flex;
@@ -89,10 +85,7 @@ export default ({ data }) => {
                 <meta name="description" content={talk.description} />
                 <meta name="keywords" content={`${talk.tags}`} />
             </Helmet>
-            <StyledLink to="/talks">
-                <i className="fa fa-list-alt" aria-hidden="true" /> Retour à la
-                liste
-            </StyledLink>
+            <BackToList path="/talks" />
             <TalkContainer>
                 <DateAndSpeakers>
                     <Calendar date={talk.date} edition={talk.edition} />


### PR DESCRIPTION

## Description

En breakpoint mobile le contenu est collé à la headerbar, ce qui n'est pas très esthétique.
De plus le bouton "Retour à la liste" était tronqué.

![image](https://user-images.githubusercontent.com/12797391/47043347-b5790000-d18d-11e8-966c-7b58ca742d1d.png)

Le composant BackToList comprend le lien qui s'affiche en dessous de la page speaker et talk, pour retourner à la liste. Je ne savais pas trop ou le mettre.


