### PR TITLE
Fix date on safari

### DIFF
--- a/src/components/cccs/date.js
+++ b/src/components/cccs/date.js
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import locale from 'date-fns/locale/fr';
 import format from 'date-fns/format';
+import parseISO from 'date-fns/parseISO';
 
 const DateContainer = styled.div`
     background-color: ${({ theme }) => theme.white};
@@ -36,8 +37,9 @@ const Schedule = styled.span`
 `;
 
 export default ({ date }) => {
+
     const [day, month, year, schedules] = format(
-        new Date(date),
+        parseISO(date),
         'dd-MMM-yyyy-HH:mm',
         {
             locale,

--- a/src/components/talks/Calendar.js
+++ b/src/components/talks/Calendar.js
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import locale from 'date-fns/locale/fr';
 import format from 'date-fns/format';
+import parseISO from 'date-fns/parseISO';
 
 const Container = styled.div`
     border-radius: 0.5rem;
@@ -104,8 +105,9 @@ const Schedule = styled.span`
 `;
 
 export default ({ date, edition }) => {
+
     const [day, month, year, schedules] = format(
-        new Date(date),
+        parseISO(date),
         'dd-MMM-yyyy-HH:mm',
         {
             locale,


### PR DESCRIPTION
Issue reference: resolve #88 

## Description

Fix "Invalid time value" sur Safari.

Il semblerait que Safari (& IE parait il) ne supporte pas les dates au format MySQL, comme renseigné dans le markdown au format `2018-12-24 18:30` tandis que Firefox et Chrome y arrivent bien.

Pour palier à ça, il aura fallu convertir cette chaine dans un format de type isoString à l'aide de date-fns.

Le bug a été introduit avec la mise à jours des deps et le passage à date-fns V2 puisque c'est la qu'on a commencé à utiliser des objets Date.
